### PR TITLE
added default image url to spatie media library image column

### DIFF
--- a/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -13,6 +13,8 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
 
     protected string $conversion = '';
 
+    protected ?string $defaultImageUrl = null;
+
     public function collection(string $collection): static
     {
         $this->collection = $collection;
@@ -35,6 +37,13 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
     public function getConversion(): string
     {
         return $this->conversion ?? '';
+    }
+
+    public function defaultImageUrl(string $url): static
+    {
+        $this->defaultImageUrl = $url;
+
+        return $this;
     }
 
     public function getImagePath(): ?string
@@ -67,7 +76,7 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
             return $state;
         }
 
-        return $record->getFirstMediaUrl($this->getCollection(), $this->getConversion());
+        return  $record->getFirstMediaUrl($this->getCollection(), $this->getConversion()) ?? $this->defaultImageUrl;
     }
 
     public function applyEagerLoading(Builder | Relation $query): Builder | Relation


### PR DESCRIPTION
I have added a default image URL feature. If your model doesn't have any media, this method will display an image of your choice.

For example:
```php
SpatieMediaLibraryImageColumn::make('images')
    ->defaultImageUrl(url('/images/placeholder.png')) // <-- This code
    ->collection('images'),
```