### PR TITLE
Image optimisation

### DIFF
--- a/docs/02-form-components.md
+++ b/docs/02-form-components.md
@@ -110,7 +110,7 @@ SpatieMediaLibraryFileUpload::make('attachment')
     ->optimize('webp'),
 ```
 
-## Resizing images
+### Resizing images
 
 You may also want to resize an image by passing in a percentage you would like to reduce the image by. This will also maintain aspect ratio.
 

--- a/docs/02-form-components.md
+++ b/docs/02-form-components.md
@@ -97,3 +97,27 @@ SpatieMediaLibraryFileUpload::make('attachments')
         'thumb' => ['orientation' => '90'],
     ]),
 ```
+
+## Optimizing images
+
+Before uploading your image, you may choose to optimize it by converting to your chosen format. The file saved to your disk will be the converted version only.
+
+```php
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+
+SpatieMediaLibraryFileUpload::make('attachment')
+    ->image()
+    ->optimize('webp'),
+```
+
+## Resizing images
+
+You may also want to resize an image by passing in a percentage you would like to reduce the image by. This will also maintain aspect ratio.
+
+```php
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+
+SpatieMediaLibraryFileUpload::make('attachment')
+    ->image()
+    ->resize(50),
+```


### PR DESCRIPTION
I'm submitting this PR to add image optimization and resizing functionality to the v2 SpatieMediaLibraryFileUpload plugin.

### The issue at hand:
Currently, when you upload an image and use conversions with `media-library`, the original file is saved with its corresponding versions provided on your model. 

This is fine if you have a lot of disk space, but what if you'd rather reduce the file sizes before uploading - especially in the case where you know you'll never need to save 10 x 10MB images the user has uploaded.

### The following changes have been made:

#### optimize()

A new `optimize()` method has been added.

- Converts the binary image to an `InterventionImage` object
- Optimises it by reducing its file size when passing in a `(string)` image extension to convert to

E.g. I want to convert my image to 'webp': 

```php
use Filament\Forms\Components\SpatieMediaLibraryFileUpload;

SpatieMediaLibraryFileUpload::make('attachment')
    ->image()
    ->optimize('webp'),
```

Uploaded image is now in webp format.

#### resize()

A new `resize()` method has also been added. 
- Gets the `InterventionImage` object and resizes it by taking in an `(int)` percentage to reduce the image dimensions
- Maintains aspect ratio

E.g. I'd like to reduce my image (1280px x 720px) by 50%:
```php
use Filament\Forms\Components\SpatieMediaLibraryFileUpload;

SpatieMediaLibraryFileUpload::make('attachment')
    ->image()
    ->resize(50),
```
Uploaded image size is 640px x 360px.

As mentioned, these chained methods will replace the original file(s) uploaded. I.e. the versions saved to the disk are the converted images only. 