### PR TITLE
Handle Null Relation Error in Spatie Media Library

### DIFF
--- a/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -83,6 +83,10 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
             $record = $record->getRelationValue($this->getRelationshipName());
         }
 
+        if (is_null($record)) {
+            return [];
+        }
+
         return $record->getRelationValue('media')
             ->filter(fn (Media $media): bool => blank($collection) || ($media->getAttributeValue('collection_name') === $collection))
             ->sortBy('order_column')


### PR DESCRIPTION
When using a relation with the Tables\Columns\SpatieMediaLibraryImageColumn in the Spatie Media Library, if that relation is null, we encounter a null error in the $this->queriesRelationships within the getState(): array method.

To address this issue, we proactively check for null records in the relations. Before retrieving $record->getRelationValue('media'), we verify for null and, if applicable, return an empty array."