### PR TITLE
Add support for defaultImageUrl

### DIFF
--- a/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
+++ b/src/Tables/Columns/SpatieMediaLibraryImageColumn.php
@@ -48,14 +48,14 @@ class SpatieMediaLibraryImageColumn extends ImageColumn
         }
 
         if (! $record) {
-            return null;
+            return $this->defaultImageUrl() ?? null;
         }
 
         /** @var ?Media $media */
         $media = $record->media->first(fn (Media $media): bool => $media->uuid === $state);
 
         if (! $media) {
-            return null;
+            return $this->defaultImageUrl() ?? null;
         }
 
         $conversion = $this->getConversion();


### PR DESCRIPTION
Spatie extends ImageColumn and ImageColumn natively supports defaultImageUrl. This adds native support for the default image url capabilities.