### PR TITLE
Use Spatie Media Libraries mime types

### DIFF
--- a/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -261,6 +261,19 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             ->each(fn (Media $media) => $media->delete());
     }
 
+    public function getAcceptedFileTypes(): ?array
+    {
+        if (! $this->acceptedFileTypes) {
+            $this->acceptedFileTypes(
+                $this->getRecord()
+                    ->getMediaCollection($this->getCollection() ?? 'default')
+                    ->acceptsMimeTypes
+            );
+        }
+
+        return parent::getAcceptedFileTypes();
+    }
+
     public function getDiskName(): string
     {
         if ($diskName = $this->evaluate($this->diskName)) {


### PR DESCRIPTION
This PR allows the usage of mime types defined on the media collection object. If no mime types have been defined on the Filament input component, it will default to using the collections mime types. If none, exist, then it continues to work as normal.

#### Media library collection example with defined mime types

```
public function registerMediaCollections(): void
{
    $this->addMediaCollection('logo')
        ->acceptsMimeTypes(['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml'])
        ->singleFile();
}
```

With the above example, it becomes unnecessary to use `acceptedFileTypes()` to define or duplicate the same mime types. 

What this solves is the following flow where mime types are defined on the collection, but not on the Filament media input field:

1. User uploads a file disallowed by the collection.
2. Filament is unaware of the disallowed file showing the upload was successful.
3. Clicking save on the form throws an error stating the disallowed mime type.