### PR TITLE
Fix typo in the fileAttachmentProvider method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ class Post extends Model implements HasRichContent
     public function setUpRichContent(): void
     {
         $this->registerRichContent('content')
-            ->fileAttachmentsProvider(SpatieMediaLibraryFileAttachmentProvider::make());
+            ->fileAttachmentProvider(SpatieMediaLibraryFileAttachmentProvider::make());
     }
 }
 ```
@@ -210,7 +210,7 @@ class Post extends Model implements HasRichContent
     public function setUpRichContent(): void
     {
         $this->registerRichContent('content')
-            ->fileAttachmentsProvider(
+            ->fileAttachmentProvider(
                 SpatieMediaLibraryFileAttachmentProvider::make()
                     ->collection('content-file-attachments'),
             );


### PR DESCRIPTION
here is a typo in the readme file: the method name for the setUpRichContent function is **fileAttachmentProvider** not fileAttachment**s**Provider